### PR TITLE
Add rate limiting for automated responses

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -8,7 +8,7 @@ const lastResponseTimes = new Map(); // Map<string, number>
 
 function timeoutSet(identifier) {
 	const currentTimeout = lastResponseTimes.get(identifier);
-	return currentTimeout !== null && currentTimeout !== undefined;
+	return currentTimeout !== null && typeof currentTimeout !== "undefined";
 }
 
 function timeoutEnded(identifier, timeoutMs) {
@@ -389,7 +389,7 @@ module.exports = async (client, message) => {
 			forbiddenMinCount = 1;
 			adjustedMinCount = Number.MIN_SAFE_INTEGER; // disable the "good words offset" feature
 			replyMessage = {
-			"embed": {
+				"embed": {
 					"title": "Automated message alert",
 					"description": "We are unable to provide support for plugins installed via third-party repo. Please contact the plugin creator directly or ask in their support discords.",
 					"color": client.config.EMBED_ERROR_COLOR,

--- a/events/message.js
+++ b/events/message.js
@@ -7,7 +7,8 @@ const MINUTE = 60 * SECOND;
 const lastResponseTimes = new Map(); // Map<string, number>
 
 function timeoutSet(identifier) {
-	return lastResponseTimes.get(identifier) != null;
+	const currentTimeout = lastResponseTimes.get(identifier);
+	return currentTimeout !== null && currentTimeout !== undefined;
 }
 
 function timeoutEnded(identifier, timeoutMs) {
@@ -374,7 +375,8 @@ module.exports = async (client, message) => {
 				forbidAny = [];
 				forbidCount = [];
 				negateBadWords = [];
-			} else if (timeoutSet(sectionIdentifier)) {
+			}
+			else if (timeoutSet(sectionIdentifier)) {
 				console.log(`${sectionIdentifier} timeout not exceeded; ignoring message`);
 			}
 		}
@@ -405,20 +407,21 @@ module.exports = async (client, message) => {
 			forbidAny = [];
 			forbidCount = [];
 			negateBadWords = [];
-		} else if (timeoutSet(sectionIdentifier)) {
+		}
+		else if (timeoutSet(sectionIdentifier)) {
 			console.log(`${sectionIdentifier} timeout not exceeded; ignoring message`);
 		}
 
 		sectionIdentifier = "suggestions";
 		if (timeoutEnded(sectionIdentifier, 15 * MINUTE)) {
 			// These need to be set to things about suggestions
-			//forbidAny.push(/(bdth|burn[ing]* down the house)/gui);
-			//forbidCount.push(/(install|help|support|download|update|use|using|where|find|issue|problem|command)/gui);
+			// forbidAny.push(/(bdth|burn[ing]* down the house)/gui);
+			// forbidCount.push(/(install|help|support|download|update|use|using|where|find|issue|problem|command)/gui);
 			negateBadWords = [];
 			forbiddenMinCount = 1;
 			adjustedMinCount = Number.MIN_SAFE_INTEGER; // disable the "good words offset" feature
 			replyMessage = {
-			"embed": {
+				"embed": {
 					"title": "Automated message alert",
 					"description": "If you are proposing a new plugin and have a GitHub account, please consider opening an issue on the [suggestions repository](https://github.com/goatcorp/suggestions/issues/new?assignees=&labels=discussion+requested&template=plugin_request.md&title=).",
 					"color": client.config.EMBED_ERROR_COLOR,
@@ -436,7 +439,8 @@ module.exports = async (client, message) => {
 			forbidAny = [];
 			forbidCount = [];
 			negateBadWords = [];
-		} else if (timeoutSet(sectionIdentifier)) {
+		}
+		else if (timeoutSet(sectionIdentifier)) {
 			console.log(`${sectionIdentifier} timeout not exceeded; ignoring message`);
 		}
 	}

--- a/events/message.js
+++ b/events/message.js
@@ -398,6 +398,35 @@ module.exports = async (client, message) => {
 			forbidCount = [];
 			negateBadWords = [];
 		}
+
+		sectionIdentifier = "suggestions";
+		if (timeoutEnded(sectionIdentifier, 15 * MINUTE)) {
+			// These need to be set to things about suggestions
+			//forbidAny.push(/(bdth|burn[ing]* down the house)/gui);
+			//forbidCount.push(/(install|help|support|download|update|use|using|where|find|issue|problem|command)/gui);
+			//negateBadWords = [];
+			forbiddenMinCount = 1;
+			adjustedMinCount = Number.MIN_SAFE_INTEGER; // disable the "good words offset" feature
+			replyMessage = {
+			"embed": {
+					"title": "Automated message alert",
+					"description": "If you are proposing a new plugin and have a GitHub account, please consider opening an issue on the [suggestions repository](https://github.com/goatcorp/suggestions/issues/new?assignees=&labels=discussion+requested&template=plugin_request.md&title=).",
+					"color": client.config.EMBED_ERROR_COLOR,
+					"footer": {
+						"text": client.config.TRIGGER_FOOTER,
+					},
+				},
+			};
+
+			checkTheMessage(message, forbidAny, forbidCount, negateBadWords, forbiddenMinCount, adjustedMinCount, ignoredRoles, true, replyMessage);
+
+			resetTimeout(sectionIdentifier);
+
+			// bandaid, clear all the important variables
+			forbidAny = [];
+			forbidCount = [];
+			negateBadWords = [];
+		}
 	}
 
 	// Triggers for Project Meteor

--- a/events/message.js
+++ b/events/message.js
@@ -11,11 +11,11 @@ function makeTimeoutManager() {
 		const currentTimeout = lastResponseTimes.get(identifier);
 		return currentTimeout !== null && typeof currentTimeout !== "undefined";
 	}
-	
+
 	function timeoutEnded(identifier, timeoutMs) {
 		return !timeoutSet(identifier) || Date.now() - lastResponseTimes.get(identifier) > timeoutMs;
 	}
-	
+
 	function resetTimeout(identifier) {
 		lastResponseTimes.set(identifier, Date.now());
 	}
@@ -24,10 +24,10 @@ function makeTimeoutManager() {
 		timeoutSet,
 		timeoutEnded,
 		resetTimeout,
-	}
+	};
 }
 
-const timeoutManager = makeTimeoutManager()
+const timeoutManager = makeTimeoutManager();
 
 function checkTheMessage(message, forbidAny, forbidCount, negateBadWords, forbiddenMinCount, adjustedMinCount, ignoredRoles, ignorelength, replyMessage) {
 	if (message.member.roles.cache.some(r => ignoredRoles.includes(r.name))) {

--- a/events/message.js
+++ b/events/message.js
@@ -344,7 +344,7 @@ module.exports = async (client, message) => {
 
 		// disabled as no new patches
 		let sectionIdentifier = "newpatch";
-		if (client.config.NEWFFXIVPATCH && timeoutEnded(sectionIdentifier, 5 * SECOND)) {
+		if (client.config.NEWFFXIVPATCH && timeoutEnded(sectionIdentifier, 3 * SECOND)) {
 			forbidAny.push(/(plugin|dalamud|launcher|in-game|in game|XL|XIVLauncher|XIV Launcher|combo|moaction|mouseover)/igu);
 			forbidCount.push(/(update|(not|n't)\s+(work|exist|use)|when|eta|why|yet)+(?!.*\1)/igu);
 			forbiddenMinCount = 2;
@@ -372,7 +372,7 @@ module.exports = async (client, message) => {
 		}
 
 		sectionIdentifier = "bdth";
-		if (timeoutEnded(sectionIdentifier, 5 * SECOND)) {
+		if (timeoutEnded(sectionIdentifier, 3 * SECOND)) {
 			forbidAny.push(/(bdth|burn[ing]* down the house)/gui);
 			forbidCount.push(/(install|help|support|download|update|use|using|where|find|issue|problem|command)/gui);
 			negateBadWords = [];


### PR DESCRIPTION
This wraps the automated responses for goat place in in-memory timeouts to avoid franzbot sending the same responses repeatedly when the same trigger occurs multiple times in a short interval.

This does not add the triggers for suggestions, or wrap Meteor or zu responses in timeouts.