### PR TITLE
Prefix command (Mac)

### DIFF
--- a/config/915959680080171018/faqs/prefix.js
+++ b/config/915959680080171018/faqs/prefix.js
@@ -1,0 +1,21 @@
+exports.answer = async client => ({
+	title: `How do I find the XIV on Mac prefix?`,
+	description: `The XIV on Mac prefix is a folder that contains important WINE configurations and system data for XIV on Mac App.`
+		+ `The XIV on Mac application data folder or "Prefix" is located at ~/Library/Application Support/XIV on MAC `
+		+ `\n\nFor more information, see `
+		+ `[HERE](https://www.xivmac.com/faq#q-prefix-folder?)`,
+	color: client.config.EMBED_NORMAL_COLOR,
+	footer: {
+		"text": client.config.FRANZBOT_VERSION,
+	},
+});
+
+exports.info = {
+	name: "prefix",
+	category: "help",
+	aliases: [
+		"prefix",
+		"xivonmacprefix",
+		"xivonmacfolder",
+	],
+};


### PR DESCRIPTION
Bot command to tell the user how to find their XIV on Mac prefix/application data.