### PR TITLE
Application Requirements Command (Mac)

### DIFF
--- a/config/915959680080171018/faqs/reqs.js
+++ b/config/915959680080171018/faqs/reqs.js
@@ -1,0 +1,21 @@
+exports.answer = async client => ({
+	title: `XIV on Mac Application Requirements`,
+	description: `The XIV on Mac Application currently requires macOS Big Sur 11.6+ or higher.`
+		+ ``
+		+ `\n\nPlease visit our website to see additional hardware reqs & fps estimates, see `
+		+ `[HERE](https://www.xivmac.com/faq#q-xiv-on-mac-app-reqs)`,
+	color: client.config.EMBED_NORMAL_COLOR,
+	footer: {
+		"text": client.config.FRANZBOT_VERSION,
+	},
+});
+
+exports.info = {
+	name: "reqs",
+	category: "help",
+	aliases: [
+		"reqs",
+		"req",
+		"requirements",
+	],
+};


### PR DESCRIPTION
Advises user of which supported OS version is usable and redirects to hardware requirements/estimates page on xivmac.com