### PR TITLE
Why does using the recommended settings trigger give the preferences one?

### DIFF
--- a/config/915959680080171018/faqs/preferences.js
+++ b/config/915959680080171018/faqs/preferences.js
@@ -20,6 +20,6 @@ exports.info = {
 		"xompreferences",
 		"pref",
 		"prefs",
-		"recommended",
+		
 	],
 };


### PR DESCRIPTION
Well, it's fixed