### PR TITLE
custom repo faq with wider image

### DIFF
--- a/config/581875019861328007/faqs/customrepoexplainer.js
+++ b/config/581875019861328007/faqs/customrepoexplainer.js
@@ -10,7 +10,7 @@ exports.answer = async client => ({
         + 'You can also upload and analyze the tspack yourself [HERE](https://loggy.goat.place/).',
     color: client.configdb.get("EMBED_WARN_COLOR"),
     image: {
-        "url": "https://media.discordapp.net/attachments/687530726756712478/1196967126230118430/image.png",
+        "url": "https://cdn.discordapp.com/attachments/1084906540592549958/1456784123027783801/launchwithoutcustomrepoplugins.jpg",
     },
     footer: {
         "text": client.configdb.get("FRANZBOT_VERSION"),


### PR DESCRIPTION
updated example image to be a bit wider (and consequently match the current (as of now) Windows styling, should make the discord embed not so squashed and not eat up nearly as much of the chat. Hopefully. If it doesn't do as designed then guess I'll cry

The image is currently posted in the game-crashes channel of goatplace and as a result of how discord's cdn works it'll be viewable IN Discord but trying to get to it outside fails.